### PR TITLE
Adding synchronization to resolve issue DROOLS-144.

### DIFF
--- a/kie-internal/src/main/java/org/kie/internal/utils/CompositeClassLoader.java
+++ b/kie-internal/src/main/java/org/kie/internal/utils/CompositeClassLoader.java
@@ -98,7 +98,7 @@ public class CompositeClassLoader extends ClassLoader {
      * This ClassLoader never has classes of it's own, so only search the child ClassLoaders
      * and the parent ClassLoader if one is provided
      */
-    public Class< ? > loadClass(final String name,
+    public synchronized Class< ? > loadClass(final String name,
                                 final boolean resolve) throws ClassNotFoundException {
         Class cls = loader.get().load( this,
                                        name,
@@ -114,7 +114,7 @@ public class CompositeClassLoader extends ClassLoader {
     * This ClassLoader never has classes of it's own, so only search the child ClassLoaders
     * and the parent ClassLoader if one is provided
     */
-   public Class< ? > loadClass(final String name,
+   public synchronized Class< ? > loadClass(final String name,
                                final boolean resolve,
                                final ClassLoader ignore) throws ClassNotFoundException {
        Class cls = loader.get().load( this,


### PR DESCRIPTION
This fix is tested on JDK 1.6. In Java 7 there is a different way to do centralized synchronization per class, however it is only support for Java 7+, to support Java <=6 need to use old school synchronized key word.