### PR TITLE
[DROOLS-579] Wrong doc for RuleRuntime.getQueryResults - throwing RuntimeException instead of empty results

### DIFF
--- a/kie-api/src/main/java/org/kie/api/runtime/rule/RuleRuntime.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/rule/RuleRuntime.java
@@ -73,7 +73,9 @@ public interface RuleRuntime
      *            The arguments used for the query
      *
      * @return The QueryResults of the specified query.
-     *         If the query does not exist or no results match the query it is empty.
+     *         If no results match the query it is empty.
+     * 
+     * @throws RuntimeException If the query does not exist
      */
     public QueryResults getQueryResults(String query,
                                         Object... arguments);


### PR DESCRIPTION
I know there is no obligation to document unchecked exceptions, but here the doc was explicitly saying something different.

Ref https://issues.jboss.org/browse/DROOLS-579