### PR TITLE
add org.uberfire.domain

### DIFF
--- a/kie-docs/shared/Workbench/Installation/Installation.xml
+++ b/kie-docs/shared/Workbench/Installation/Installation.xml
@@ -145,6 +145,11 @@
       </listitem>
 
       <listitem>
+        <para><emphasis role="bold"><literal>org.uberfire.domain</literal></emphasis>: security-domain name used by
+        uberfire. Default: <literal>ApplicationRealm</literal></para>
+      </listitem>
+
+      <listitem>
         <para><emphasis role="bold"><literal>org.guvnor.m2repo.dir</literal></emphasis>: Place where Maven repository
           folder will be stored. Default: working-directory/repositories/kie</para>
       </listitem>


### PR DESCRIPTION
Added an explanaiton for org.uberfire.domain system property.

TBH, I doubt that the value 'ApplicationRealm' is a good default. 'ApplicationRealm' is not a security-domain name so it falls back to 'other'. I'll raise a JIRA for it.