### PR TITLE
DROOLS-729 changed super(null); to super() for Android

### DIFF
--- a/kie-internal/src/main/java/org/kie/internal/utils/CompositeClassLoader.java
+++ b/kie-internal/src/main/java/org/kie/internal/utils/CompositeClassLoader.java
@@ -40,7 +40,7 @@ public class CompositeClassLoader extends ClassLoader {
     private final AtomicReference<Loader> loader       = new AtomicReference<Loader>();
 
     public CompositeClassLoader() {
-        super( null );
+        super();
         loader.set( new DefaultLoader() );
     }
     


### PR DESCRIPTION
Android base classloader implemention doesn't allow the null value for the parent argument.  It throws an exception.