### PR TITLE
KieScanner works also with the RELEASE setting

### DIFF
--- a/kie-docs/shared/KIE/BuildDeployUtilizeAndRun/KIEDeploying.xml
+++ b/kie-docs/shared/KIE/BuildDeployUtilizeAndRun/KIEDeploying.xml
@@ -93,7 +93,7 @@ kScanner.start( 10000L );</programlisting>
     it automatically downloads the new version and triggers an incremental build of the new
     project. From this moment all the new <code>KieBase</code>s and <code>KieSession</code>s
     created from that <code>KieContainer</code> will use the new project version.</para>
-	<para>The <code>KieScanner</code> will only pickup changes to deployed jars if it is using a SNAPSHOT, version range, or the LATEST setting. 
+	<para>The <code>KieScanner</code> will only pickup changes to deployed jars if it is using a SNAPSHOT, version range, the LATEST, or the RELEASE setting. 
 	Fixed versions will not automatically update at runtime.
 	</para>
   </section>


### PR DESCRIPTION
At least, this is my experience using 6.2.0.Final, and I hope I'm not wrong =)

Made explicit in the doc as I felt the need to test it, in order to be sure this was indeed a use-case available (also using "RELEASE setting" or not) as this was not explicitly mentioned in the doc, if compared to the following paragraph where all the settings are explained in details.

Thank you, hope this helps.
MM