### PR TITLE
BZ-1210672 - Runtime manager problems in Switchyard environments (Set nitialized to true only if init succeeds)

### DIFF
--- a/kie-api/src/main/java/org/kie/api/runtime/manager/RuntimeManagerFactory.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/manager/RuntimeManagerFactory.java
@@ -111,13 +111,17 @@ public interface RuntimeManagerFactory {
         }
 
         private static RuntimeManagerFactory create(ClassLoader classLoader) {
-            initialized = true;
             try {
                 String className = System.getProperty("org.jbpm.runtime.manager.class",
                                                       "org.jbpm.runtime.manager.impl.RuntimeManagerFactoryImpl" );
-                return classLoader != null ?
+                RuntimeManagerFactory runtimeManagerFactory =  classLoader != null ?
                        ( RuntimeManagerFactory ) Class.forName( className, true, classLoader ).newInstance() :
                        ( RuntimeManagerFactory ) Class.forName( className ).newInstance();
+                       
+                 // only set initialized to true after an instance really has been created      
+                 initialized = true;
+                 
+                 return runtimeManagerFactory;
             } catch (Exception e) {
                 logger.error("Unable to instance RuntimeManagerFactory due to " + e.getMessage());
             }


### PR DESCRIPTION
When David (@dvirgiln) was testing the fix for BZ-1210672, we noticed that if the classloader does not find the class, the `initialized` boolean is still set to true. 

Does this seem like a good fix for that problem? If so, please merge this. 