### PR TITLE
Renamed CorrelationKeyFactory method parameter

### DIFF
--- a/kie-internal/src/main/java/org/kie/internal/process/CorrelationKeyFactory.java
+++ b/kie-internal/src/main/java/org/kie/internal/process/CorrelationKeyFactory.java
@@ -22,5 +22,5 @@ public interface CorrelationKeyFactory {
 
     CorrelationKey newCorrelationKey(String businessKey);
     
-    CorrelationKey newCorrelationKey(List<String> properties);
+    CorrelationKey newCorrelationKey(List<String> businessKeys);
 }


### PR DESCRIPTION
Current method parameters looks inconsistent, can look like method with "properties" parameter set something different than method with businessKey parameter.
"properties" is list of business keys so I think that renaming it will make methods functionality and their relation more understandable.