### PR TITLE
fix javadoc about lnglevel

### DIFF
--- a/kie-internal/src/main/java/org/kie/internal/builder/KnowledgeBuilderConfiguration.java
+++ b/kie-internal/src/main/java/org/kie/internal/builder/KnowledgeBuilderConfiguration.java
@@ -57,7 +57,7 @@ import org.kie.internal.builder.conf.KnowledgeBuilderOptionsConfiguration;
  * The Java dialect supports the following configurations:
  * <ul>
  * <li>drools.dialect.java.compiler = &lt;ECLIPSE|JANINO&gt;</li>
- * <li>drools.dialect.java.lngLevel = &lt;1.5|1.6&gt;</li>
+ * <li>drools.dialect.java.compiler.lnglevel = &lt;1.5|1.6&gt;</li>
  * </ul>
  * 
  * And MVEL supports the following configurations:


### PR DESCRIPTION
drools.dialect.java.compiler.lnglevel is the correct system property name.

https://github.com/tkobayas/drools/blob/master/drools-core/src/main/java/org/drools/core/rule/builder/dialect/asm/ClassLevel.java#L26
