### PR TITLE
DROOLS-912 - adding the ability to create the audit log from the Command API

### DIFF
--- a/kie-api/src/main/java/org/kie/api/command/KieCommands.java
+++ b/kie-api/src/main/java/org/kie/api/command/KieCommands.java
@@ -124,6 +124,10 @@ public interface KieCommands {
     Command<FactHandle> fromExternalFactHandleCommand(String factHandleExternalForm, boolean disconnected);
 
     Command newAgendaGroupSetFocus(String name);
+    
+    Command newEnableAuditLog( String directory, String filename );
+    
+    Command newEnableAuditLog( String filename );
 
 }
 

--- a/kie-api/src/main/java/org/kie/api/command/KieCommands.java
+++ b/kie-api/src/main/java/org/kie/api/command/KieCommands.java
@@ -124,10 +124,5 @@ public interface KieCommands {
     Command<FactHandle> fromExternalFactHandleCommand(String factHandleExternalForm, boolean disconnected);
 
     Command newAgendaGroupSetFocus(String name);
-    
-    Command newEnableAuditLog( String directory, String filename );
-    
-    Command newEnableAuditLog( String filename );
 
 }
-

--- a/kie-internal/src/main/java/org/kie/internal/command/CommandFactory.java
+++ b/kie-internal/src/main/java/org/kie/internal/command/CommandFactory.java
@@ -44,7 +44,7 @@ import java.util.Map;
  * <p>This api is experimental and thus the classes and the interfaces returned are subject to change.</p>  
  */
 public class CommandFactory {
-    private static volatile KieCommands provider;
+    private static volatile ExtendedKieCommands provider;
 
     /**
      * Inserts a new instance
@@ -368,11 +368,11 @@ public class CommandFactory {
                                                               lookup);
     }
 
-    private static synchronized void setCommandFactoryProvider(KieCommands provider) {
+    private static synchronized void setCommandFactoryProvider( ExtendedKieCommands provider) {
         CommandFactory.provider = provider;
     }
 
-    private static synchronized KieCommands getCommandFactoryProvider() {
+    private static synchronized ExtendedKieCommands getCommandFactoryProvider() {
         if ( provider == null ) {
             loadProvider();
         }
@@ -381,7 +381,7 @@ public class CommandFactory {
 
     private static void loadProvider() {
         try {
-            Class<KieCommands> cls = (Class<KieCommands>) Class.forName( "org.drools.core.command.impl.CommandFactoryServiceImpl" );
+            Class<ExtendedKieCommands> cls = (Class<ExtendedKieCommands>) Class.forName( "org.drools.core.command.impl.CommandFactoryServiceImpl" );
             setCommandFactoryProvider( cls.newInstance() );
         } catch ( Exception e2 ) {
             throw new RuntimeException( "Provider org.drools.core.command.impl.CommandFactoryProviderImpl could not be set.",

--- a/kie-internal/src/main/java/org/kie/internal/command/CommandFactory.java
+++ b/kie-internal/src/main/java/org/kie/internal/command/CommandFactory.java
@@ -396,4 +396,12 @@ public class CommandFactory {
     public static Command<FactHandle> fromExternalFactHandleCommand(String factHandleExternalForm, boolean disconnected) {
         return getCommandFactoryProvider().fromExternalFactHandleCommand(factHandleExternalForm, disconnected);
     }
+    
+    public static Command newEnableAuditLog( String directory, String filename ){
+        return getCommandFactoryProvider().newEnableAuditLog( directory, filename );
+    }
+    
+    public static Command newEnableAuditLog( String filename ){
+        return getCommandFactoryProvider().newEnableAuditLog( filename );
+    }
 }

--- a/kie-internal/src/main/java/org/kie/internal/command/ExtendedKieCommands.java
+++ b/kie-internal/src/main/java/org/kie/internal/command/ExtendedKieCommands.java
@@ -1,0 +1,12 @@
+package org.kie.internal.command;
+
+import org.kie.api.command.Command;
+import org.kie.api.command.KieCommands;
+
+public interface ExtendedKieCommands extends KieCommands {
+
+    public Command newEnableAuditLog( String directory, String filename );
+
+    public Command newEnableAuditLog( String filename );
+
+}


### PR DESCRIPTION
Made necessary changes to the Command Factory to support this feature, there is a another PR for drools-core: https://github.com/droolsjbpm/drools/pull/497