### PR TITLE
[DROOLS 840] workaround JDK 8 compile compatibility issue

### DIFF
--- a/kie-internal/src/main/java/org/kie/internal/runtime/manager/RuntimeManagerRegistry.java
+++ b/kie-internal/src/main/java/org/kie/internal/runtime/manager/RuntimeManagerRegistry.java
@@ -61,7 +61,12 @@ public class RuntimeManagerRegistry {
 	}
 	
 	public Collection<String> getRegisteredIdentifiers() {
-	    return Collections.unmodifiableCollection(this.registeredManager.keySet());
+		// Using "registeredManager.keySet()" directly would result in issues when compiling with JDK 8+. The "keySet()"
+		// method returns type ConcurrentHashMap$KeySetView which is only available in Java 8+. That means
+		// the bytecode would contain reference to that type, which does not exist in Java 6 and Java 7 and thus
+		// clients would get NoSuchMethodError at runtime. The "keys()" method is fully backwards compatible, but it
+		// requires wrapping inside additional collection as "unmodifiableCollection()" does not accept Enumerations.
+	    return Collections.unmodifiableCollection(Collections.list(this.registeredManager.keys()));
 	}
 	
 }

--- a/kie-internal/src/main/java/org/kie/internal/runtime/manager/RuntimeManagerRegistry.java
+++ b/kie-internal/src/main/java/org/kie/internal/runtime/manager/RuntimeManagerRegistry.java
@@ -22,51 +22,51 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.kie.api.runtime.manager.RuntimeManager;
 
 public class RuntimeManagerRegistry {
-	
-	private static RuntimeManagerRegistry INSTANCE = new RuntimeManagerRegistry();
 
-	protected volatile ConcurrentHashMap<String, RuntimeManager> registeredManager = new ConcurrentHashMap<String, RuntimeManager>();
-		
-	private RuntimeManagerRegistry() {
-		
-	}
-	
-	public static RuntimeManagerRegistry get() {
-		return INSTANCE;
-	}
-	
-	public synchronized void register(RuntimeManager manager) {
-		if (registeredManager.containsKey(manager.getIdentifier())) {
-			throw new IllegalStateException("RuntimeManager is already registered with id " + manager.getIdentifier());
-		}
-		this.registeredManager.put(manager.getIdentifier(), manager);
-	}
-	
-	public synchronized void remove(RuntimeManager manager) {
+    private static RuntimeManagerRegistry INSTANCE = new RuntimeManagerRegistry();
 
-		this.registeredManager.remove(manager.getIdentifier());
-	}
-	
-	public synchronized void remove(String identifier) {
+    protected volatile ConcurrentHashMap<String, RuntimeManager> registeredManager = new ConcurrentHashMap<String, RuntimeManager>();
 
-		this.registeredManager.remove(identifier);
-	}
-	
-	public RuntimeManager getManager(String id) {
-		return this.registeredManager.get(id);
-	}
-	
-	public boolean isRegistered(String id) {
-		return this.registeredManager.containsKey(id);
-	}
-	
-	public Collection<String> getRegisteredIdentifiers() {
-		// Using "registeredManager.keySet()" directly would result in issues when compiling with JDK 8+. The "keySet()"
-		// method returns type ConcurrentHashMap$KeySetView which is only available in Java 8+. That means
-		// the bytecode would contain reference to that type, which does not exist in Java 6 and Java 7 and thus
-		// clients would get NoSuchMethodError at runtime. The "keys()" method is fully backwards compatible, but it
-		// requires wrapping inside additional collection as "unmodifiableCollection()" does not accept Enumerations.
-	    return Collections.unmodifiableCollection(Collections.list(this.registeredManager.keys()));
-	}
-	
+    private RuntimeManagerRegistry() {
+
+    }
+
+    public static RuntimeManagerRegistry get() {
+        return INSTANCE;
+    }
+
+    public synchronized void register(RuntimeManager manager) {
+        if (registeredManager.containsKey(manager.getIdentifier())) {
+            throw new IllegalStateException("RuntimeManager is already registered with id " + manager.getIdentifier());
+        }
+        this.registeredManager.put(manager.getIdentifier(), manager);
+    }
+
+    public synchronized void remove(RuntimeManager manager) {
+
+        this.registeredManager.remove(manager.getIdentifier());
+    }
+
+    public synchronized void remove(String identifier) {
+
+        this.registeredManager.remove(identifier);
+    }
+
+    public RuntimeManager getManager(String id) {
+        return this.registeredManager.get(id);
+    }
+
+    public boolean isRegistered(String id) {
+        return this.registeredManager.containsKey(id);
+    }
+
+    public Collection<String> getRegisteredIdentifiers() {
+        // Using "registeredManager.keySet()" directly would result in issues when compiling with JDK 8+. The "keySet()"
+        // method returns type ConcurrentHashMap$KeySetView which is only available in Java 8+. That means
+        // the bytecode would contain reference to that type, which does not exist in Java 6 and Java 7 and thus
+        // clients would get NoSuchMethodError at runtime. The "keys()" method is fully backwards compatible, but it
+        // requires wrapping inside additional collection as "unmodifiableCollection()" does not accept Enumerations.
+        return Collections.unmodifiableCollection(Collections.list(this.registeredManager.keys()));
+    }
+
 }


### PR DESCRIPTION
Second option is to define the `registeredManager` as `Map` instead of `ConcurrentHashMap` (the implementation will of course stay the same). With proper comment (to make sure it won't get changed back), that should work as well.