### PR TITLE
ENTESB-4090 - Fixing fuse integration (Fuse hack breaks kie-remote-client usage in Fuse code)

### DIFF
--- a/kie-api/src/main/java/org/kie/api/runtime/rule/QueryResultsRow.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/rule/QueryResultsRow.java
@@ -21,4 +21,18 @@ package org.kie.api.runtime.rule;
  */
 public interface QueryResultsRow extends Row {
 
+    /**
+     * Return the Object for the given Declaration identifier.
+     * @param identifier
+     * @return the Object
+     */
+    public Object get(String identifier);
+
+    /**
+     * Return the {@link FactHandle} for the given Declaration identifier.
+     * @param identifier
+     * @return the {@link FactHandle} instance
+     */
+    public FactHandle getFactHandle(String identifier);
+
 }


### PR DESCRIPTION
Related to https://github.com/droolsjbpm/drools/pull/516

See the [drools PR](https://github.com/droolsjbpm/drools/pull/516) for the full explanation. 

(as well as PR's on droolsjbpm-integration and fuse-bxms-integ). 