### PR TITLE
Adding possibility to create Clear commands using CommandFactory

### DIFF
--- a/kie-internal/src/main/java/org/kie/internal/command/ExtendedKieCommands.java
+++ b/kie-internal/src/main/java/org/kie/internal/command/ExtendedKieCommands.java
@@ -9,4 +9,11 @@ public interface ExtendedKieCommands extends KieCommands {
 
     public Command newEnableAuditLog( String filename );
 
+    public Command newClearActivationGroup(String name);
+
+    public Command newClearAgenda();
+
+    public Command newClearAgendaGroup(String name);
+
+    public Command newClearRuleFlowGroup(String name);
 }


### PR DESCRIPTION
In droolsjbpm/drools#464 there was added possibility to create clear commands in CommandFactoryServiceImpl. This PR reflects this change into command factory interface.

Added to ExtendedKieCommands according to https://github.com/droolsjbpm/droolsjbpm-knowledge/pull/95