### PR TITLE
revapi: classify methods added to inerface as only potentially breaking

### DIFF
--- a/kie-api/pom.xml
+++ b/kie-api/pom.xml
@@ -109,26 +109,14 @@
                 <artifact>${project.groupId}:${project.artifactId}:6.3.0.Final</artifact>
               </oldArtifacts>
               <newArtifacts>
-                <!-- The special BUILD GAV is used to specify artifacts that were produced during the build of the current project.-->
+                <!-- The special 'BUILD' GAV is used to specify artifacts that were produced during the build of the current project. -->
                 <artifact>BUILD</artifact>
               </newArtifacts>
-              <!-- In case some changes are expected, the following configuration example shows how to prevent a build
-                   from failing.
-              <analysisConfiguration>
-                  {
-                    "revapi" : {
-                      "reclassify" : [
-                        {
-                          "regex" : true,
-                          "code" : "java.method.addedToInterface",
-                          "classify" : {
-                            "SOURCE": "POTENTIALLY_BREAKING"
-                          }
-                        }
-                      ]
-                    }
-                  }
-              </analysisConfiguration> -->
+              <analysisConfigurationFiles>
+                <configurationFile>
+                  <path>src/build/revapi-config.json</path>
+                </configurationFile>
+              </analysisConfigurationFiles>
             </configuration>
             <!-- Running two executions is a workaround to make sure we get a HTML report in case revapi finds
                  some incompatible changes. The "check" goal will simply fail the whole build before it could get

--- a/kie-api/src/build/revapi-config.json
+++ b/kie-api/src/build/revapi-config.json
@@ -1,0 +1,16 @@
+{
+  "revapi" : {
+    "ignore" : [
+      {
+        "code" : "java.method.addedToInterface",
+        "new" : "method org.kie.api.runtime.KieSessionConfiguration org.kie.api.runtime.KieContainer::getKieSessionConfiguration()",
+        "justification" : "Enables retrieving the default session configuration directly from KieContainer."
+      },
+      {
+        "code" : "java.method.addedToInterface",
+        "new" : "method org.kie.api.runtime.KieSessionConfiguration org.kie.api.runtime.KieContainer::getKieSessionConfiguration(java.lang.String)",
+        "justification" : "Enables retrieving the named session configuration directly from KieContainer."
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Most of our interfaces are in fact _not_ meant to be directly implemented by users (e.g. KieSession, KieSessionConfiguration, KieBase). Users are usually using them to abstract away from the different implementations we may provide, so adding a method in such interface should not breaking change in most of the cases (in fact I can not think of any such breaking case, but that surely does not mean there is none).

@mrietveld, @rsynek please take a look and let me know what you think.