### PR TITLE
[DO NOT MERGE!] JBPM-4303: Add a queue-based implementation of the process engine

### DIFF
--- a/kie-api/src/build/revapi-config.json
+++ b/kie-api/src/build/revapi-config.json
@@ -73,6 +73,11 @@
         "code": "java.method.addedToInterface",
         "new": "method java.util.Map<java.lang.String, java.lang.Object> org.kie.api.task.model.TaskData::getTaskOutputVariables()",
         "justification": "Provides access to task output variables directly from a task"
+      },
+      {
+        "code" : "java.method.removed",
+        "old" : "method void org.kie.api.runtime.process.EventListener::signalEvent(java.lang.String, java.lang.Object)",
+        "justification" : "The .signalEvent(String, Object) method has been moved to the (parent) EventSignallable interface."
       }
     ]
   }

--- a/kie-api/src/main/java/org/kie/api/runtime/EnvironmentName.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/EnvironmentName.java
@@ -33,7 +33,9 @@ public class EnvironmentName {
     public static final String GLOBALS                              = "org.kie.Globals";
     public static final String CALENDARS                            = "org.kie.api.time.Calendars";
     public static final String DATE_FORMATS                         = "org.kie.build.DateFormats";
-    
+
     public static final String TASK_USER_GROUP_CALLBACK             = "org.kie.api.task.UserGroupCallback";
     public static final String TASK_USER_INFO                       = "org.kie.api.task.UserInfo";
+
+    public static final String USE_STACKLESS_EXECUTION              = "org.jbpm.engine.execution.stackless";
 }

--- a/kie-api/src/main/java/org/kie/api/runtime/process/EventListener.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/process/EventListener.java
@@ -20,22 +20,13 @@ package org.kie.api.runtime.process;
  * An interface that represents an element that is listening
  * for specific types of events.
  */
-public interface EventListener {
-
-    /**
-     * Signals that an event has occurred. The type parameter defines
-     * which type of event and the event parameter can contain additional information
-     * related to the event.
-     * 
-     * @param type the type of event
-     * @param event the data associated with this event
-     */
-    void signalEvent(String type, 
-                     Object event);
+public interface EventListener extends EventSignallable {
 
     /**
      * Returns the event types this event listener is interested in.
      * May return <code>null</code> if the event types are unknown.
+     *
+     * @return a {@link String} array of the types of events that this element listens to
      */
     String[] getEventTypes();
 

--- a/kie-api/src/main/java/org/kie/api/runtime/process/EventSignallable.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/process/EventSignallable.java
@@ -1,0 +1,19 @@
+package org.kie.api.runtime.process;
+
+/**
+ * An interface that represents an element that can be signalled by specific types of events.
+ */
+public interface EventSignallable {
+
+    /**
+     * Signals that an event has occurred. The type parameter defines
+     * which type of event and the event parameter can contain additional information
+     * related to the event.
+     *
+     * @param type the type of event
+     * @param event the data associated with this event
+     */
+    void signalEvent(String type,
+                     Object event);
+
+}


### PR DESCRIPTION
@krisv Could you "bless" this? 

That is to say, moving the `signalEvent(type, event)` method to `EventSignallable`. That way, both `EventListener` and `EventNodeInstanceInterface` can implement `EventSignallable`, which helps me not have to write some methods twice. 

Thanks. 

DO NOT MERGE!