### PR TITLE
[BZ-1312164] optionally osgi-import drools-wb-models-guided-dtable package

### DIFF
--- a/kie-internal/pom.xml
+++ b/kie-internal/pom.xml
@@ -51,6 +51,7 @@
               org.drools.core.marshalling.impl;resolution:=optional,
               org.drools.core.util,
               org.drools.decisiontable;resolution:=optional,
+              org.drools.workbench.models.guided.dtable.backend;resolution:=optional,
               org.drools.persistence.jpa;resolution:=optional,
               org.jbpm.bpmn2;resolution:=optional,
               org.jbpm.marshalling.impl;resolution:=optional,


### PR DESCRIPTION
 * only guided-dtable support for now. Rest (pmml, scorecards) will be coming
   in future


@mariofusco could you please review?