### PR TITLE
[DROOLS-1129] consistent OSGi Bundle-SymbolicName for all jars

### DIFF
--- a/kie-api/pom.xml
+++ b/kie-api/pom.xml
@@ -15,6 +15,10 @@
   <name>KIE :: Public API</name>
   <description>The Drools and jBPM public API which is backwards compatible between releases.</description>
 
+  <properties>
+    <osgi.Bundle-SymbolicName>org.kie.api</osgi.Bundle-SymbolicName>
+  </properties>
+
   <build>
     <plugins>
       <plugin>
@@ -22,7 +26,6 @@
         <artifactId>maven-bundle-plugin</artifactId>
         <configuration>
           <instructions>
-            <Bundle-SymbolicName>org.kie.api</Bundle-SymbolicName>
             <Import-Package>
               *;resolution:=optional,
               org.jbpm.runtime.manager.impl;resolution:=optional,

--- a/kie-internal/pom.xml
+++ b/kie-internal/pom.xml
@@ -15,6 +15,10 @@
   <name>KIE :: Internal</name>
   <description>The Drools and jBPM internal API which is NOT backwards compatible between releases.</description>
 
+  <properties>
+    <osgi.Bundle-SymbolicName>org.kie.internal.api</osgi.Bundle-SymbolicName>
+  </properties>
+
   <build>
     <resources>
       <resource>
@@ -32,7 +36,6 @@
         <artifactId>maven-bundle-plugin</artifactId>
         <configuration>
           <instructions>
-            <Bundle-SymbolicName>org.kie.internalapi</Bundle-SymbolicName>
             <Import-Package>
               com.sun.tools.xjc;resolution:=optional,
               com.thoughtworks.xstream;resolution:=optional,


### PR DESCRIPTION
Depends on:
https://github.com/droolsjbpm/droolsjbpm-build-bootstrap/pull/183