### PR TITLE
Add interface for filtering Java classes out of KIE project builds.

### DIFF
--- a/kie-internal/src/main/java/org/kie/internal/builder/InternalKieBuilder.java
+++ b/kie-internal/src/main/java/org/kie/internal/builder/InternalKieBuilder.java
@@ -16,6 +16,8 @@
 
 package org.kie.internal.builder;
 
+import java.util.function.Predicate;
+
 import org.kie.api.builder.KieBuilder;
 import org.kie.api.builder.KieModule;
 
@@ -26,4 +28,13 @@ public interface InternalKieBuilder extends KieBuilder {
     KieModule getKieModuleIgnoringErrors();
 
     IncrementalResults incrementalBuild();
+
+    /**
+     * Builds all the KieBases contained in the KieModule for which this KieBuilder has been created
+     * @param classFilter Used to prevent compilation of Java source files.
+     *          This filter will be tested on all source file names before they are compiled.
+     *          Only source files for which the filter returns true will be compiled.
+     */
+    KieBuilder buildAll(Predicate<String> classFilter);
+
 }


### PR DESCRIPTION
This PR is required for LiveSpark, where we require the ability to prevent client-side classes with GWT dependencies from being compiled.