### PR TITLE
RHBRMS-2552 Use version property for Kie release.

### DIFF
--- a/kie-api/pom.xml
+++ b/kie-api/pom.xml
@@ -102,7 +102,7 @@
         <artifactId>revapi-maven-plugin</artifactId>
         <configuration>
           <oldArtifacts>
-            <artifact>${project.groupId}:${project.artifactId}:6.4.0.Final</artifact>
+            <artifact>${project.groupId}:${project.artifactId}:${version.org.kie.latestFinal.release}</artifact>
           </oldArtifacts>
           <newArtifacts>
             <!-- The special 'BUILD' GAV is used to specify artifacts that were produced during the build of the current project. -->


### PR DESCRIPTION
Use the version property for the latest Kie release in revapi-maven-plugin
when checking API compatibility.

Please also see : https://github.com/droolsjbpm/droolsjbpm-build-bootstrap/pull/270