### PR TITLE
DROOLS-1237 MBean statistics from String property to proper JMX table.

### DIFF
--- a/kie-api/src/build/revapi-config.json
+++ b/kie-api/src/build/revapi-config.json
@@ -2,6 +2,12 @@
   "revapi" : {
     "ignore" : [
       {
+          "code": "java.class.removed",
+          "old": "class org.kie.api.management.KieSessionMonitoringMBean",
+          "justification": "Interface moved from MBean type to MXBean type, so interface is now KieSessionMonitoringMXBean"
+      }
+      ,
+      {
           "code": "java.method.removed",
           "old": "method double org.kie.api.management.KieSessionMonitoringMBean::getAverageFiringTime()",
           "justification": "Method was NOT removed, but moved to superinterface, ref github.com/revapi/revapi/issues/41"

--- a/kie-api/src/main/java/org/kie/api/management/GenericKieSessionMonitoringMXBean.java
+++ b/kie-api/src/main/java/org/kie/api/management/GenericKieSessionMonitoringMXBean.java
@@ -24,7 +24,7 @@ import javax.management.ObjectName;
 /**
  * An MBean interface for {@link org.kie.api.runtime.KieSession} monitoring
  */
-public interface GenericKieSessionMonitoringMBean {
+public interface GenericKieSessionMonitoringMXBean {
 
     /**
      * Resets all stats
@@ -71,33 +71,55 @@ public interface GenericKieSessionMonitoringMBean {
     double getAverageFiringTime();
 
     /**
-     * Returns a formatted String with statistics for a single rule in this session,
-     * like number of matches created, cancelled and fired as well as firing time.
-     *  
-     * @param ruleName the name of the rule for which statistics are requested.
-     * 
-     * @return formatted String with statistics
-     */
-    String getStatsForRule(String ruleName);
-
-    /**
      * @return the timestamp of the last stats reset
      */
     Date getLastReset();
     
-    Map<String,String> getStatsByRule();
+    
+    public static interface IAgendaStatsData {
+        long getMatchesFired();
+        long getMatchesCreated();
+        long getMatchesCancelled();
+        long getFiringTime();
+        Date getLastReset();
+    }
+    /**
+     * Returns the statistics for a single rule in this session,
+     * like number of matches created, cancelled and fired as well as firing time.
+     *  
+     * @param ruleName the name of the rule for which statistics are requested.
+     * 
+     * @return the statistics for a single rule in this session
+     */
+    IAgendaStatsData getStatsForRule(String ruleName);
+    Map<String, IAgendaStatsData> getStatsByRule();
 
+    
     long getTotalProcessInstancesStarted();
     
     long getTotalProcessInstancesCompleted();
     
-    String getStatsForProcess(String processId);
     
-    Map<String,String> getStatsByProcess();
+    public static interface IGlobalProcessStatsData {
+        long getProcessInstancesStarted();
+        long getProcessInstancesCompleted();
+        Date getLastReset();
+    }
+    public static interface IProcessStatsData extends IGlobalProcessStatsData {
+        long getProcessNodesTriggered();
+    }
+    IProcessStatsData getStatsForProcess(String processId);
+    Map<String,IProcessStatsData> getStatsByProcess();
     
-    String getStatsForProcessInstance(long processInstanceId);
     
-    Map<Long,String> getStatsByProcessInstance();
+    public static interface IProcessInstanceStatsData {
+        Date getProcessStarted();
+        Date getProcessCompleted();
+        long getProcessNodesTriggered();
+    }
+    IProcessInstanceStatsData getStatsForProcessInstance(long processInstanceId);
+    Map<Long,IProcessInstanceStatsData> getStatsByProcessInstance();
+    
 
     String getKieSessionName();
     

--- a/kie-api/src/main/java/org/kie/api/management/KieSessionMonitoringMXBean.java
+++ b/kie-api/src/main/java/org/kie/api/management/KieSessionMonitoringMXBean.java
@@ -16,11 +16,17 @@
 
 package org.kie.api.management;
 
-/**
- * An MBean interface for {@link org.kie.api.runtime.StatelessKieSession} monitoring
- */
-public interface StatelessKieSessionMonitoringMBean extends GenericKieSessionMonitoringMBean {
+import java.util.Date;
+import java.util.Map;
 
-    long getTotalObjectsInserted();
-    long getTotalObjectsDeleted();
+import javax.management.ObjectName;
+
+/**
+ * An MBean interface for {@link org.kie.api.runtime.KieSession} monitoring
+ */
+public interface KieSessionMonitoringMXBean extends GenericKieSessionMonitoringMXBean {
+    /**        
+     * @return the total fact count current loaded into the session      
+     */       
+    long getTotalFactCount();
 }

--- a/kie-api/src/main/java/org/kie/api/management/StatelessKieSessionMonitoringMXBean.java
+++ b/kie-api/src/main/java/org/kie/api/management/StatelessKieSessionMonitoringMXBean.java
@@ -16,17 +16,11 @@
 
 package org.kie.api.management;
 
-import java.util.Date;
-import java.util.Map;
-
-import javax.management.ObjectName;
-
 /**
- * An MBean interface for {@link org.kie.api.runtime.KieSession} monitoring
+ * An MBean interface for {@link org.kie.api.runtime.StatelessKieSession} monitoring
  */
-public interface KieSessionMonitoringMBean extends GenericKieSessionMonitoringMBean {
-    /**        
-     * @return the total fact count current loaded into the session      
-     */       
-    long getTotalFactCount();
+public interface StatelessKieSessionMonitoringMXBean extends GenericKieSessionMonitoringMXBean {
+
+    long getTotalObjectsInserted();
+    long getTotalObjectsDeleted();
 }


### PR DESCRIPTION
MBean currently provide statistics as a String property list for
historical reasons.
As JMX supports Table as Maps, rework them as proper JMX Table support.