### PR TITLE
Promoting methods to the public API as they are used by core extensio…

### DIFF
--- a/kie-api/src/build/revapi-config.json
+++ b/kie-api/src/build/revapi-config.json
@@ -293,7 +293,12 @@
        "old": "method java.util.List<java.lang.String> org.kie.api.task.UserGroupCallback::getGroupsForUser(java.lang.String, java.util.List<java.lang.String>, java.util.List<java.lang.String>)",
        "new": "method java.util.List<java.lang.String> org.kie.api.task.UserGroupCallback::getGroupsForUser(java.lang.String)",
        "justification": "Removed unused and confusing arguments"
-     }
+      },
+      {
+       "code": "java.method.addedToInterface",
+       "new": "method <T> T org.kie.api.runtime.KieSession::getKieRuntime(java.lang.Class<T>)",
+       "justification": "Promoting internal method getKieRuntime() to the public API"
+      }
     ]
   }
 }

--- a/kie-api/src/main/java/org/kie/api/runtime/KieSession.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/KieSession.java
@@ -129,9 +129,24 @@ public interface KieSession
     void submit(AtomicAction action);
 
     /**
+     * Returns a runtime for the given interface. This method is used to retrieve runtime
+     * extensions to the engine. It is used as the hook point for the custom pluggable
+     * knowledge extensions like the bayes engine and the DMN engine.
+     *
+     * E.g.:
+     *
+     * <code>DMNRuntime dmnRuntime = session.getKieRuntime( DMNRuntime.class );</code>
+     *
+     * @param cls the runtime interface for the extension
+     * @return the runtime instance for the extension
+     */
+    <T> T getKieRuntime(Class<T> cls);
+
+    /**
      * An action that will be executed atomically on this session.
      */
     interface AtomicAction {
         void execute(KieSession kieSession);
     }
+
 }

--- a/kie-internal/src/main/java/org/kie/internal/utils/KieHelper.java
+++ b/kie-internal/src/main/java/org/kie/internal/utils/KieHelper.java
@@ -77,7 +77,7 @@ public class KieHelper {
         return kieContainer.newKieBase(kieBaseConf);
     }
 
-    protected KieContainer getKieContainer() {
+    public KieContainer getKieContainer() {
         KieBuilder kieBuilder = ks.newKieBuilder( kfs, classLoader ).buildAll();
         Results results = kieBuilder.getResults();
         if (results.hasMessages(Message.Level.ERROR)) {


### PR DESCRIPTION
Promoting methods to the public API as they are used by core extensions like the DMN implementation.

More details about the core extensions here:

http://blog.athico.com/2014/08/pluggable-knowledge-with-custom.html

In particular the getRuntime() method already existed in the internal class implementation:

https://github.com/droolsjbpm/drools/blob/master/drools-core/src/main/java/org/drools/core/impl/StatefulKnowledgeSessionImpl.java#L390

but in order to allow users to access the extensions, we have to promote it to the public API, as this PR is doing.