### PR TITLE
JBPM-5708 MapDB implementation of persistence for Drools and jBPM

### DIFF
--- a/kie-api/src/build/revapi-config.json
+++ b/kie-api/src/build/revapi-config.json
@@ -356,6 +356,32 @@
         "justification": "DROOLS-1419 Generify AccumulateFunction to make it less verbose to implement. This is backwards compatible."
       },
       {
+       "code": "java.method.addedToInterface",
+       "new": "method java.lang.String org.kie.api.task.model.Task::getFormName()",
+       "justification": "Moved from InternalTask to tidy up interfaces"
+      },
+      {
+       "code": "java.method.returnTypeChanged",
+       "old": "method int org.kie.api.task.model.Task::getPriority()",
+       "new": "method java.lang.Integer org.kie.api.task.model.Task::getPriority()",
+       "justification": "Changed so that Task and TaskSummary interfaces match, and we can implement them with the same type if desired"
+      },
+      {
+       "code": "java.method.addedToInterface",
+       "new": "method java.lang.Integer org.kie.api.task.model.Task::getVersion()",
+       "justification": "Changed from int to Integer to make all types alligned (either primitives everywhere, or wrappers)"
+      },
+      {
+       "code": "java.method.addedToInterface",
+       "new": "method java.lang.Boolean org.kie.api.task.model.Task::isArchived()",
+       "justification": "Moved from InternalTask to tidy up interfaces"
+      },
+      {
+       "code": "java.method.addedToInterface",
+       "new": "method <T> T org.kie.api.runtime.KieSession::getKieRuntime(java.lang.Class<T>)",
+       "justification": "Promoting internal method getKieRuntime() to the public API"
+      },
+      {
         "code": "java.class.removed",
         "old": "class org.kie.api.runtime.conf.TimedRuleExectionOption",
         "package": "org.kie.api.runtime.conf",

--- a/kie-api/src/main/java/org/kie/api/persistence/ObjectStoringStrategy.java
+++ b/kie-api/src/main/java/org/kie/api/persistence/ObjectStoringStrategy.java
@@ -1,0 +1,34 @@
+package org.kie.api.persistence;
+
+public interface ObjectStoringStrategy {
+
+    /**
+     * Similar to ObjectMarshallingStrategy, it is used to 
+     * decide whether this implementation is going to work for 
+     * the given Object.
+     * @param obj a given object
+     * @return true if it can persist the given object.
+     */
+    boolean accept(Object obj);
+    
+    /**
+     * Returns the key for the persisted object.
+     * @param persistable the object to persist.
+     * @return the key of the persisted object.
+     */
+    Object persist(Object persistable);
+    
+    /**
+     * Returns the key for the persisted object.
+     * @param persistable the object to persist.
+     * @return the key of the persisted object.
+     */
+    Object update(Object persistable);
+    
+    /**
+     * Returns the persisted object.
+     * @param key the key of the persisted object.
+     * @return a persisted object or null.
+     */
+    Object read(Object key);
+}

--- a/kie-api/src/main/java/org/kie/api/task/model/Task.java
+++ b/kie-api/src/main/java/org/kie/api/task/model/Task.java
@@ -23,7 +23,7 @@ public interface Task extends Externalizable {
 
     Long getId();
 
-    int getPriority();
+    Integer getPriority();
 
     List<I18NText> getNames();
 
@@ -42,5 +42,11 @@ public interface Task extends Externalizable {
     TaskData getTaskData();
 
     String getTaskType();
+
+    Boolean isArchived();
+
+    Integer getVersion();
+
+    String getFormName();
 
 }

--- a/kie-internal/src/main/java/org/kie/internal/task/api/TaskPersistenceContext.java
+++ b/kie-internal/src/main/java/org/kie/internal/task/api/TaskPersistenceContext.java
@@ -28,7 +28,10 @@ import org.kie.api.task.model.OrganizationalEntity;
 import org.kie.api.task.model.Task;
 import org.kie.api.task.model.TaskSummary;
 import org.kie.api.task.model.User;
+import org.kie.internal.task.api.model.ContentData;
 import org.kie.internal.task.api.model.Deadline;
+import org.kie.internal.task.api.model.FaultData;
+import org.kie.internal.task.api.model.InternalTaskData;
 
 public interface TaskPersistenceContext {
 
@@ -81,6 +84,10 @@ public interface TaskPersistenceContext {
     Attachment updateAttachment(Attachment attachment);
 
     Attachment removeAttachment(Attachment attachment);
+    
+    Attachment removeAttachmentFromTask(Task task, long attachmentId);
+    
+    Attachment addAttachmentToTask(Attachment attachment, Task task);
 
     Comment findComment(Long commentId);
 
@@ -89,6 +96,10 @@ public interface TaskPersistenceContext {
     Comment updateComment(Comment comment);
 
     Comment removeComment(Comment comment);
+    
+    Comment removeCommentFromTask(Comment comment, Task task);
+    
+    Comment addCommentToTask(Comment comment, Task task);
 
     Deadline findDeadline(Long deadlineId);
 
@@ -98,6 +109,13 @@ public interface TaskPersistenceContext {
 
     Deadline removeDeadline(Deadline deadline);
 
+    Task setDocumentToTask(Content content, ContentData contentData, Task task);
+    
+    Task setFaultToTask(Content content, FaultData faultData, Task task);
+    
+    Task setOutputToTask(Content content, ContentData contentData, Task task);
+    
+    
     /*
      * Query related methods
      */
@@ -119,6 +137,8 @@ public interface TaskPersistenceContext {
     <T> T queryAndLockStringWithParametersInTransaction(String queryName, Map<String, Object> params, boolean singleResult, Class<T> clazz);
 
     int executeUpdateString(String updateString);
+    
+    int executeUpdate(String queryName, Map<String, Object> params);
 
     HashMap<String, Object> addParametersToMap(Object ... parameterValues);
 
@@ -148,4 +168,5 @@ public interface TaskPersistenceContext {
      */
 
     List<TaskSummary> doTaskSummaryCriteriaQuery(String userId, UserGroupCallback userGroupCallback, Object queryWhere);
+
 }

--- a/kie-internal/src/main/java/org/kie/internal/task/api/model/ContentData.java
+++ b/kie-internal/src/main/java/org/kie/internal/task/api/model/ContentData.java
@@ -31,4 +31,8 @@ public interface ContentData extends Externalizable {
     byte[] getContent();
 
     void setContent(byte[] content);
+    
+    Object getContentObject();
+    
+    void setContentObject(Object object);
 }

--- a/kie-internal/src/main/java/org/kie/internal/task/api/model/InternalTask.java
+++ b/kie-internal/src/main/java/org/kie/internal/task/api/model/InternalTask.java
@@ -25,21 +25,15 @@ import org.kie.api.task.model.TaskData;
 
 public interface InternalTask extends Task {
 
-    void setId(long id);
-
-    Boolean isArchived();
+    void setId(Long id);
 
     void setArchived(Boolean archived);
 
-    int getVersion();
-
-    void setPriority(int priority);
+    void setPriority(Integer priority);
 
     void setNames(List<I18NText> names);
 
     void setFormName(String formName);
-
-    String getFormName();
 
     void setSubjects(List<I18NText> subjects);
 
@@ -63,9 +57,10 @@ public interface InternalTask extends Task {
 
     void setSubTaskStrategy(SubTasksStrategy subTaskStrategy);
 
-
     void setName(String name);
+
     void setSubject(String subject);
+    
     void setDescription(String description);
 
 }


### PR DESCRIPTION
Implementation of MapDB persistence layer for Drools and jBPM persistence. This requires a set of modifications:
 - Creating drools-persistence-api and jbpm-persistence-api
 - SingleSessionCommandService refactors
 - PersistenceContext and ProcessPersistenceContext refactors:
 - TaskPersistenceContext refactors
 - Changes in the current persistence model interfaces
 - TimerJobFactoryManager / TimerService refactors